### PR TITLE
test: Only start the test case after daemon fully started

### DIFF
--- a/.github/runtest.sh
+++ b/.github/runtest.sh
@@ -7,6 +7,14 @@ TEST_ARTIFACTS_FOLDER="./test_artifacts/"
 CONTAINER_WORKSPACE="/workspace/rabc"
 CONTAINER_TEST_ARTIFACTS_FOLDER="/test_artifacts"
 
+if [ -n "$1" ];then
+    CONTAINER_IMAGE="quay.io/librabc/$1"
+else
+    if [ -z "$CONTAINER_IMAGE" ];then
+        CONTAINER_IMAGE="quay.io/librabc/c9s-rabc-ci"
+    fi
+fi
+
 CONTAINER_ID=""
 
 function cleanup {
@@ -23,7 +31,7 @@ mkdir $TEST_ARTIFACTS_FOLDER || true
 CONTAINER_ID=$(podman run -it -d \
     -v $PROJECT_PATH:$CONTAINER_WORKSPACE \
     -v $TEST_ARTIFACTS_FOLDER:$CONTAINER_TEST_ARTIFACTS_FOLDER \
-    $1 /bin/bash
+    $CONTAINER_IMAGE /bin/bash
 )
 
 podman exec -i $CONTAINER_ID \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,8 +89,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container_image: "quay.io/librabc/c8s-rabc-ci"
-          - container_image: "quay.io/librabc/c9s-rabc-ci"
+          - container_image: "c8s-rabc-ci"
+          - container_image: "c9s-rabc-ci"
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a example project to demonstrate my practise on linux
 system library in Rust containing:
- * A echo server listening on UNIX socket `/tmp/librabc`.
+ * A echo server `rabcd` listening on UNIX socket `/tmp/librabc`.
  * Rust crate connect above socket and send `ping` every 10 seconds.
- * C/Python
- * Command line tool for the client.
+ * C/Python binding
+ * Command line tool for the client `rabcc`.

--- a/tests/integration/rabc_test.py
+++ b/tests/integration/rabc_test.py
@@ -5,10 +5,13 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 import pytest
 
 from rabc import RabcClient
+
+DAEMON_MAX_WAIT_TIME = 50   # 5 seconds
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -19,6 +22,15 @@ def rabc_daemon():
         stderr=subprocess.PIPE,
         preexec_fn=os.setsid,
     )
+    i = 0
+    while i < DAEMON_MAX_WAIT_TIME:
+        i += 1
+        time.sleep(0.1)
+        try:
+            RabcClient()
+            break
+        except Exception:
+            continue
     yield
     os.killpg(daemon.pid, signal.SIGTERM)
 


### PR DESCRIPTION
It take time for daemon to start the listening on socket, when test case
starts we should wait daemon to be fully started. To do that, we check
`RabcClient()` every 0.1 seconds with 50 retries.
