### PR TITLE
Introduce ASYNC support

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -18,5 +18,6 @@ path = "rabcc.rs"
 [dependencies]
 env_logger = "0.9.0"
 log = "0.4.17"
-rabc = { "version" = "0.1", path = "../lib" }
-tokio = { "version" = "1.19.2", features = ["rt", "net", "macros"] }
+rabc = { "version" = "0.1", path = "../lib", features = ["async"] }
+tokio = { "version" = "1.19.2", features = [ "macros", "rt-multi-thread"] }
+futures = "0.3"

--- a/src/cli/rabcc.rs
+++ b/src/cli/rabcc.rs
@@ -1,20 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use rabc::RabcClient;
+use futures::stream::StreamExt;
+use rabc::RabcClientAsync;
 
-const WAIT_TIME: u32 = 10;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main()]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_logger();
-    let mut client = RabcClient::new()?;
-    for _ in 0..10 {
-        let events = client.poll(WAIT_TIME)?;
-        println!("Got events {:?}", events);
-        for event in events {
-            log::debug!("Got event {}", event);
-            if let Some(reply) = client.process(&event)? {
-                println!("Got reply from daemon {:?}", reply);
-            }
+    let mut client = RabcClientAsync::new()?;
+    for i in 0..10 {
+        if let Some(reply) = client.next().await {
+            log::info!("{i}: Got reply from daemon: {}", reply?);
         }
     }
     Ok(())

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -18,7 +18,20 @@ path = "lib.rs"
 log = "0.4.17"
 tokio = { version = "1.19.2", features = ["net"] }
 
+[dependencies.futures]
+version = "0.3"
+optional = true
+
+[dependencies.libc]
+version = "0.2"
+optional = true
+
 [dependencies.nix]
-version = "0.24.1"
+version = "0.26"
+optional = true
 default-features = false
-features = ["time", "event"]
+features = ["poll", "time", "event"]
+
+[features]
+default = []
+async = ["futures", "libc", "nix"]

--- a/src/lib/client.rs
+++ b/src/lib/client.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 
 use crate::{
     epoll::RabcEpoll, timer::RabcTimer, RabcConnection, RabcError, RabcEvent,
@@ -13,6 +13,12 @@ pub struct RabcClient {
     timer: RabcTimer,
     conn: RabcConnection,
     epoll: RabcEpoll,
+}
+
+impl AsRawFd for RabcClient {
+    fn as_raw_fd(&self) -> RawFd {
+        self.epoll.fd
+    }
 }
 
 impl RabcClient {

--- a/src/lib/client_async.rs
+++ b/src/lib/client_async.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+use futures::Stream;
+use nix::poll::{PollFd, PollFlags};
+
+use crate::{ErrorKind, RabcClient, RabcError};
+
+const POLL_TIMEOUT: libc::c_int = 1000; // milliseconds
+
+#[derive(Debug)]
+struct ShareState {
+    waker: Option<Waker>,
+}
+
+#[derive(Debug)]
+pub struct RabcClientAsync {
+    client: RabcClient,
+    shared_state: Arc<Mutex<ShareState>>,
+}
+
+impl RabcClientAsync {
+    pub fn new() -> Result<Self, RabcError> {
+        let shared_state = Arc::new(Mutex::new(ShareState { waker: None }));
+        Ok(Self {
+            client: RabcClient::new()?,
+            shared_state,
+        })
+    }
+}
+
+impl Stream for RabcClientAsync {
+    type Item = Result<String, RabcError>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        // Poll without wait
+        match self.client.poll(0) {
+            Ok(events) => {
+                for event in events {
+                    match self.client.process(&event) {
+                        Ok(Some(reply)) => {
+                            return Poll::Ready(Some(Ok(reply)));
+                        }
+                        Ok(None) => (),
+                        Err(e) => {
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("RABC client poll error: {e}");
+                return Poll::Ready(Some(Err(e)));
+            }
+        }
+
+        let mut shared_state = match self.shared_state.lock() {
+            Ok(s) => s,
+            Err(e) => {
+                return Poll::Ready(Some(Err(RabcError::new(
+                    ErrorKind::Bug,
+                    format!(
+                        "BUG: RabcClientAsync::poll_next() \
+                        Failed to acquire lock on shared_state {e}",
+                    ),
+                ))));
+            }
+        };
+        if shared_state.waker.is_none() {
+            shared_state.waker = Some(cx.waker().clone());
+            drop(shared_state);
+            let fd = self.client.as_raw_fd();
+            let shared_state = self.shared_state.clone();
+            std::thread::spawn(move || poll_thread(fd, shared_state));
+        } else {
+            shared_state.waker = Some(cx.waker().clone());
+            drop(shared_state);
+        }
+        Poll::Pending
+    }
+}
+
+impl std::ops::Drop for RabcClientAsync {
+    fn drop(&mut self) {
+        if let Ok(mut s) = self.shared_state.lock() {
+            // Signal `poll_thread()` to quit
+            s.waker = None;
+        }
+    }
+}
+
+// This function will be invoked in a thread to notify the async executor
+// via `Waker::wake()`. Will quit when `poll()` failed (except EAGAIN).
+fn poll_thread(fd: RawFd, shared_state: Arc<Mutex<ShareState>>) {
+    let mut poll_fds = [PollFd::new(
+        fd,
+        PollFlags::POLLIN
+            | PollFlags::POLLOUT
+            | PollFlags::POLLHUP
+            | PollFlags::POLLERR,
+    )];
+    loop {
+        if shared_state.lock().map(|s| s.waker.is_none()).ok() == Some(true) {
+            std::thread::sleep(std::time::Duration::from_millis(
+                POLL_TIMEOUT as u64,
+            ));
+        } else {
+            match nix::poll::poll(&mut poll_fds, POLL_TIMEOUT) {
+                // Timeout, let's check whether waker is None(client quit);
+                Ok(0) => {
+                    continue;
+                }
+                Ok(_) => match shared_state.lock() {
+                    Ok(mut s) => {
+                        if let Some(waker) = s.waker.take() {
+                            log::debug!("poll_thread got event");
+                            waker.wake();
+                        } else {
+                            log::debug!(
+                                "poll_thread got event but Waker is None"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "BUG: poll_thread() Failed to acquire lock: {e}"
+                        );
+                        return;
+                    }
+                },
+                Err(e) => {
+                    if e == nix::errno::Errno::EAGAIN {
+                        continue;
+                    } else {
+                        log::error!(
+                            "BUG: poll_thread() got error from poll(): {e}"
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -12,3 +12,8 @@ pub use crate::client::RabcClient;
 pub use crate::error::{ErrorKind, RabcError};
 pub use crate::event::RabcEvent;
 pub use crate::ipc::{RabcConnection, SOCKET_PATH};
+
+#[cfg(feature = "async")]
+mod client_async;
+#[cfg(feature = "async")]
+pub use crate::client_async::RabcClientAsync;


### PR DESCRIPTION
With `async` feature in librabc crate, you may use ASYNC functions like:

```rust
use futures::stream::StreamExt;
use rabc::RabcClientAsync;

async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let mut client = RabcClientAsync::new()?;
    if let Some(reply) = client.next().await {
        println!("Got reply from daemon: {}", reply?);
    }
    Ok(())
}
```

Changed CLI to use this ASYNC API.